### PR TITLE
remove track_features

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set rocky_version = "8.9" %}
 {% set glibc_version = "2.28" %}
 {% set kernel_headers_version = "4.18.0" %}
-{% set build_number = "0" %}
+{% set build_number = "1" %}
 
 {% set rpm_url = "https://download.rockylinux.org/vault/rocky/" ~ rocky_version ~ "/BaseOS/" ~ centos_machine ~ "/os/Packages" %}
 {% set appstream_rpm_url = "https://download.rockylinux.org/vault/rocky/" ~ rocky_version ~ "/AppStream/" ~ centos_machine ~ "/os/Packages" %}
@@ -85,15 +85,13 @@ outputs:
       noarch: generic
       binary_relocation: False
       detect_binary_files_with_prefix: False
-      track_features:
-        - sysroot_{{ cross_target_platform }}_{{ glibc_version }}
-        - sysroot_{{ cross_target_platform }}_{{ glibc_version }}_feature_2
       run_exports:
         strong:
           - __glibc >={{ glibc_version }},<3.0.a0
     requirements:
       host:
         - tzdata
+        - __glibc >={{ glibc_version }}
       run:
         - {{ pin_subpackage('kernel-headers_' ~ cross_target_platform, exact=True) }}
         - tzdata


### PR DESCRIPTION
Anaconda's distribution is moving from a default 2.17 glibc target to 2.28.
This can be controlled today by setting `c_stdlib_version` to either 2.17 or 2.28.
However, feedstocks not using the stdlib('c') macro and our cbc with c_stdlib_version set to 2.28 end up pulling the 2.17 sysroot, as the 2.28 has track features to weigh it down.
Removing the track features on the 2.28 sysroot will make it the default. 

This means users outside of Anaconda will also get 2.28 instead of 2.17. And whatever they build with this will be contrained to glibc >=2.28.

When we'll add 2.34, we'll want to set track_features on 2.34 so as to keep 2.28 as default. 

For ref, this is also discussed on conda-forge: https://github.com/conda-forge/linux-sysroot-feedstock/issues/68

