### PR TITLE
linux-sysroot 2.34 

### DIFF
--- a/recipe/build-sysroot.sh
+++ b/recipe/build-sysroot.sh
@@ -5,7 +5,9 @@ mkdir -p ${PREFIX}/${target_machine}-${ctng_vendor}-linux-gnu/sysroot
 pushd ${PREFIX}/${target_machine}-${ctng_vendor}-linux-gnu/sysroot > /dev/null 2>&1
 cp -Rf "${SRC_DIR}"/binary-glibc/* .
 mkdir -p usr/include
-cp -Rf "${SRC_DIR}"/binary-glibc-headers/include/* usr/include/
+if [[ ${cross_target_platform} = linux-64 ]] ; then
+    cp -Rf "${SRC_DIR}"/binary-glibc-headers/include/* usr/include/
+fi
 cp -Rf "${SRC_DIR}"/binary-glibc-devel/* usr/
 cp -Rf "${SRC_DIR}"/binary-glibc-static/* usr/
 cp -Rf "${SRC_DIR}"/binary-glibc-common/* usr/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,11 +1,11 @@
-{% set rocky_version = "8.9" %}
-{% set glibc_version = "2.28" %}
-{% set kernel_headers_version = "4.18.0" %}
-{% set build_number = "1" %}
+{% set rocky_version = "9.5" %}
+{% set glibc_version = "2.34" %}
+{% set kernel_headers_version = "5.14.0" %}
+{% set build_number = "0" %}
 
 {% set rpm_url = "https://download.rockylinux.org/vault/rocky/" ~ rocky_version ~ "/BaseOS/" ~ centos_machine ~ "/os/Packages" %}
 {% set appstream_rpm_url = "https://download.rockylinux.org/vault/rocky/" ~ rocky_version ~ "/AppStream/" ~ centos_machine ~ "/os/Packages" %}
-{% set powertools_rpm_url = "https://download.rockylinux.org/vault/rocky/" ~ rocky_version ~ "/PowerTools/" ~ centos_machine ~ "/os/Packages" %}
+{% set devel_rpm_url = "https://download.rockylinux.org/vault/rocky/" ~ rocky_version ~ "/devel/" ~ centos_machine ~ "/os/Packages" %}
 
 package:
   name: linux-sysroot
@@ -16,51 +16,51 @@ source:
   # in the recipe folder (after ensuring the versions in CBC are correct)
   # START source
   - folder: binary-glibc
-    url: {{ rpm_url }}/g/glibc-2.28-236.el8_9.13.{{ centos_machine }}.rpm
-    sha256: b245492a8d830a9e2f8ee1a6d24333559bf80f885c511a7643749ce35045a1b0  # [cross_target_platform == "linux-64"]
-    sha256: 553c0240b0ff5c6c0d8aedf0bd46d6bb1a9784c9fcd04af4bff1fa56f12e6c34  # [cross_target_platform == "linux-aarch64"]
+    url: {{ rpm_url }}/g/glibc-2.34-125.el9_5.8.{{ centos_machine }}.rpm
+    sha256: b7fcc189398338475f84a2538e628de3fd0bb0ac778d66c9e4ee06e0fc177689  # [cross_target_platform == "linux-64"]
+    sha256: 7110fd3359cce2266a72df6e9b4f85320c54ca8e90ff159f58f3fe65d287698d  # [cross_target_platform == "linux-aarch64"]
 
   - folder: binary-glibc-all-langpacks
-    url: {{ rpm_url }}/g/glibc-all-langpacks-2.28-236.el8_9.13.{{ centos_machine }}.rpm
-    sha256: 6b5d8154e5879cd6b72bb39ac155f01945e31ed0f24658077984c80569062691  # [cross_target_platform == "linux-64"]
-    sha256: 33e70521847cfbdf0546ee06facf23c39741dab4e4d2c5ff75e6275999e6feef  # [cross_target_platform == "linux-aarch64"]
+    url: {{ rpm_url }}/g/glibc-all-langpacks-2.34-125.el9_5.8.{{ centos_machine }}.rpm
+    sha256: c138c3b76ee3bf0d4268068ff560c0ffb821ac0135f78ab6825c817ec3539cb2  # [cross_target_platform == "linux-64"]
+    sha256: bd033f52cd6c65b4b4faccd7c012d6af4e85a670452a847af6ea2bfe54d68d49  # [cross_target_platform == "linux-aarch64"]
 
   - folder: binary-glibc-common
-    url: {{ rpm_url }}/g/glibc-common-2.28-236.el8_9.13.{{ centos_machine }}.rpm
-    sha256: 0717831be3893442ee3433f30ce9af15789b20a91ddbad0cefa3f76707365d59  # [cross_target_platform == "linux-64"]
-    sha256: 3e0c92a02ae6704f22546c64b3e9b19dc36c724fc17fc7a3346bcaca45e77adf  # [cross_target_platform == "linux-aarch64"]
+    url: {{ rpm_url }}/g/glibc-common-2.34-125.el9_5.8.{{ centos_machine }}.rpm
+    sha256: 07878f56af2ac82507b59e13e786b7dd9811243c4230c5a310ecfb2c43877b1d  # [cross_target_platform == "linux-64"]
+    sha256: a0e38ead8793c1071f2f6e7cd6c8cb5c764e21d7b7e5f40d8c6700beadb3c3e4  # [cross_target_platform == "linux-aarch64"]
 
   - folder: binary-glibc-devel
-    url: {{ rpm_url }}/g/glibc-devel-2.28-236.el8_9.13.{{ centos_machine }}.rpm
-    sha256: f12426894a073245c0e159747edd2e43c062b1402bc6871dc8bdf6efbb564b4c  # [cross_target_platform == "linux-64"]
-    sha256: 8b38670e1c370541e4a63373b45e429f3970d9289094332b1854d899c9472570  # [cross_target_platform == "linux-aarch64"]
+    url: {{ appstream_rpm_url }}/g/glibc-devel-2.34-125.el9_5.8.{{ centos_machine }}.rpm
+    sha256: 71b669dae2d01ab784068454f2a7f196fc6a39c038f92aab025ce70909080a79  # [cross_target_platform == "linux-64"]
+    sha256: 020e899c6312b0f94d225972b2b018cd47e3c645454ac11902e63a99d985dc68  # [cross_target_platform == "linux-aarch64"]
 
   - folder: binary-glibc-gconv-extra
-    url: {{ rpm_url }}/g/glibc-gconv-extra-2.28-236.el8_9.13.{{ centos_machine }}.rpm
-    sha256: 4c71893e437e55c14020d6843a91cd33c0691c330fe9c7ce8991b839fd7b4137  # [cross_target_platform == "linux-64"]
-    sha256: 59f9a7ff7eb3abea83d38efa40a38927bc40a1c6538ec41d57eedbeb2ff7d79d  # [cross_target_platform == "linux-aarch64"]
+    url: {{ rpm_url }}/g/glibc-gconv-extra-2.34-125.el9_5.8.{{ centos_machine }}.rpm
+    sha256: 57d45448e415f7447d20320596031e01a609f102d341c3a8a2cafadacc31ac1d  # [cross_target_platform == "linux-64"]
+    sha256: 431e843b276b489f1872969fb53c17059ec576917b9ea08b9c7d849f86bfc1fa  # [cross_target_platform == "linux-aarch64"]
 
-  - folder: binary-glibc-headers
-    url: {{ rpm_url }}/g/glibc-headers-2.28-236.el8_9.13.{{ centos_machine }}.rpm
-    sha256: 8169525314b2c212da60c3f10a7515debd883fef7e056070fbc6cc4ff63eaefc  # [cross_target_platform == "linux-64"]
-    sha256: a55155dee5e2319b1bdf19d268cede6007c35e7c7a0c20b5e29b5aa0969b9132  # [cross_target_platform == "linux-aarch64"]
+  # https://forums.almalinux.org/t/glibc-headers-missing-on-aarch64-ppc64le-in-alma-9/4943
+  - folder: binary-glibc-headers                                              # [cross_target_platform == "linux-64"]
+    url: {{ appstream_rpm_url }}/g/glibc-headers-2.34-125.el9_5.8.{{ centos_machine }}.rpm  # [cross_target_platform == "linux-64"]
+    sha256: 1581f170a3e272715013f4e3d93aec13f97a79c3f720731e02369f8c59c4b169  # [cross_target_platform == "linux-64"]
 
   - folder: binary-glibc-static
-    url: {{ powertools_rpm_url }}/g/glibc-static-2.28-236.el8_9.13.{{ centos_machine }}.rpm
-    sha256: 02eac28a7fda9f3541b880ae896582765f875a8293165ca351b7b24b6d385e9e  # [cross_target_platform == "linux-64"]
-    sha256: ccab4baf384a61c857120bcf29247dfb23a4bcee97392a341b5536c556a57d67  # [cross_target_platform == "linux-aarch64"]
+    url: {{ devel_rpm_url }}/g/glibc-static-2.34-125.el9_5.8.{{ centos_machine }}.rpm
+    sha256: 999cb492a62b0fc81ef0f5535f696ff4b38be5bad6d29ace1d2779a7f35043ae  # [cross_target_platform == "linux-64"]
+    sha256: 4b6e1f3c71ad9c9aef57642f59fd8852f59fc4c58d1cef5d32c3bedcbe354744  # [cross_target_platform == "linux-aarch64"]
 
   - folder: binary-kernel-headers
-    url: {{ rpm_url }}/k/kernel-headers-4.18.0-513.24.1.el8_9.{{ centos_machine }}.rpm
-    sha256: 9e6b11688073157daa2b14868002d890f4adc3d6afe11e95cf3ee22d128c611a  # [cross_target_platform == "linux-64"]
-    sha256: 342d3ce38ce5fc9efca741a556d7f87d15c202730af80777e2c9a611001636c3  # [cross_target_platform == "linux-aarch64"]
+    url: {{ appstream_rpm_url }}/k/kernel-headers-5.14.0-503.40.1.el9_5.{{ centos_machine }}.rpm
+    sha256: c1ce3fba00143e7f225b2200b18356da5e6361ea956c9d962d12eb20d25ea301  # [cross_target_platform == "linux-64"]
+    sha256: d7b7126ba2bc1a76dcbcca857db03262910e300c6503ecaa626590a1fa9b8125  # [cross_target_platform == "linux-aarch64"]
   # END source
 
 build:
   number: {{ build_number }}
   noarch: generic
   # This package builds cross targets so only need to run once.
-  skip: True  # [not (linux and x86_64)]
+  #skip: True  # [not (linux and x86_64)]
 
 outputs:
   - name: kernel-headers_{{ cross_target_platform }}
@@ -85,6 +85,9 @@ outputs:
       noarch: generic
       binary_relocation: False
       detect_binary_files_with_prefix: False
+      track_features:
+        # this is one version advanced from the default, so one feature
+        - sysroot_{{ cross_target_platform }}_{{ glibc_version }}
       run_exports:
         strong:
           - __glibc >={{ glibc_version }},<3.0.a0
@@ -100,9 +103,9 @@ outputs:
         - test -f $PREFIX/{{ target_machine }}-conda-linux-gnu/sysroot/lib/libc.so.6
         - test -f $PREFIX/{{ target_machine }}-conda-linux-gnu/sysroot/sbin/ldconfig
         - test -f $PREFIX/{{ target_machine }}-conda-linux-gnu/sysroot/usr/lib/crt1.o
-        - test -f $PREFIX/{{ target_machine }}-conda-linux-gnu/sysroot/usr/include/limits.h
+        - test -f $PREFIX/{{ target_machine }}-conda-linux-gnu/sysroot/usr/include/limits.h        # [cross_target_platform == "linux-64"]
         - test -f $PREFIX/{{ target_machine }}-conda-linux-gnu/sysroot/usr/include/gnu/stubs-64.h  # [cross_target_platform == "linux-64"]
-        - test -f $PREFIX/{{ target_machine }}-conda-linux-gnu/sysroot/usr/include/gnu/stubs.h  # [cross_target_platform != "linux-64"]
+        - test -f $PREFIX/{{ target_machine }}-conda-linux-gnu/sysroot/usr/include/gnu/stubs.h     # [cross_target_platform != "linux-64"]
         - test -d $PREFIX/{{ target_machine }}-conda-linux-gnu/sysroot/usr/share/locale
         - test -f $PREFIX/{{ target_machine }}-conda-linux-gnu/sysroot/usr/bin/ldd
         - test -f $PREFIX/{{ target_machine }}-{{ ctng_vendor }}-linux-gnu/sysroot/lib/libc.so.6

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -105,7 +105,7 @@ outputs:
         - test -f $PREFIX/{{ target_machine }}-conda-linux-gnu/sysroot/usr/lib/crt1.o
         - test -f $PREFIX/{{ target_machine }}-conda-linux-gnu/sysroot/usr/include/limits.h        # [cross_target_platform == "linux-64"]
         - test -f $PREFIX/{{ target_machine }}-conda-linux-gnu/sysroot/usr/include/gnu/stubs-64.h  # [cross_target_platform == "linux-64"]
-        - test -f $PREFIX/{{ target_machine }}-conda-linux-gnu/sysroot/usr/include/gnu/stubs.h     # [cross_target_platform != "linux-64"]
+        - test -f $PREFIX/{{ target_machine }}-conda-linux-gnu/sysroot/usr/include/gnu/stubs.h
         - test -d $PREFIX/{{ target_machine }}-conda-linux-gnu/sysroot/usr/share/locale
         - test -f $PREFIX/{{ target_machine }}-conda-linux-gnu/sysroot/usr/bin/ldd
         - test -f $PREFIX/{{ target_machine }}-{{ ctng_vendor }}-linux-gnu/sysroot/lib/libc.so.6

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -60,7 +60,7 @@ build:
   number: {{ build_number }}
   noarch: generic
   # This package builds cross targets so only need to run once.
-  #skip: True  # [not (linux and x86_64)]
+  skip: True  # [not (linux and x86_64)]
 
 outputs:
   - name: kernel-headers_{{ cross_target_platform }}

--- a/recipe/update.py
+++ b/recipe/update.py
@@ -9,7 +9,8 @@ import hashlib
 import logging
 import requests
 import os
-from ruamel_yaml import BaseLoader, load
+import re
+from ruamel.yaml import YAML
 from packaging.version import Version
 
 parser = argparse.ArgumentParser()
@@ -25,11 +26,13 @@ if not os.path.exists(cbc):
 with open(cbc, "r", encoding="utf-8") as f:
     cbc_content = "".join(f.readlines())
 
-config = load(cbc_content, Loader=BaseLoader)
+yaml = YAML(typ='rt')
+
+config = yaml.load(cbc_content)
 rpm_arches = config["centos_machine"]
 conda_arches = config["cross_target_platform"]
 
-rocky_version = "8.9"
+rocky_version = "9.5"
 
 url_template = (
     f"https://download.rockylinux.org/vault/rocky/{rocky_version}"
@@ -39,7 +42,31 @@ url_template = (
 
 el_ver = "el" + rocky_version.replace(".", "_")
 
-# determine version of glibc & kernel-headers
+# determine version of glibc & kernel-headers; in different subfolders as of rocky 9
+
+baseos_frontpage = url_template.format(subfolder="BaseOS", arch="x86_64", letter="g")
+logging.info(f"Fetching content of {baseos_frontpage}")
+baseos_pkgs_html = requests.get(baseos_frontpage).content.decode("utf-8")
+
+appstream_frontpage = url_template.format(subfolder="AppStream", arch="x86_64", letter="k")
+logging.info(f"Fetching content of {appstream_frontpage}")
+appstream_pkgs_html = requests.get(appstream_frontpage).content.decode("utf-8")
+
+pkg_pages = [
+    # most glibc
+    url_template.format(subfolder="BaseOS", arch="x86_64", letter="g"),
+    # glibc-headers
+    url_template.format(subfolder="AppStream", arch="x86_64", letter="g"),
+    # glibc-static
+    url_template.format(subfolder="devel", arch="x86_64", letter="g"),
+    # kernel headers
+    url_template.format(subfolder="AppStream", arch="x86_64", letter="k"),
+]
+
+page_html = ""
+for page in pkg_pages:
+    logging.info(f"Fetching content of {page}")
+    page_html += requests.get(page).content.decode("utf-8")
 
 # glibc artefacts have two build numbers plus the rocky version, e.g.
 #   2.28-236.el8_9.13.x86_64.rpm
@@ -58,43 +85,39 @@ kernel_headers_version = 0
 # <html>
 # <head><title>Index of /vault/8.9/BaseOS/x86_64/os/Packages/</title></head>
 # <body>
-# <h1>Index of /vault/8.9/BaseOS/x86_64/os/Packages/</h1><hr><pre><a href="../">../</a>
-# <a href="{pkg}-{string}.x86_64.rpm">{pkg}-{string}.x86_64.rpm</a> {date} {size}
-# <a href="{pkg}-{string}.x86_64.rpm">{pkg}-{string}.x86_64.rpm</a> {date} {size}
+# <h1>Index of /vault/8.9/BaseOS/x86_64/os/Packages/</h1>
+# <table ...>
+# <tr><td ...><a href="{pkg}-{string}.x86_64.rpm" title="...">{pkg}-{string}.x86_64.rpm</a></td>... {size} {date}</tr>
 # ...
-# </pre><hr></body>
-# </html>
+# </table>
+# ...
 # ```
-for letter in ["g", "k"]:
-    baseos_frontpage = url_template.format(subfolder="BaseOS", arch="x86_64", letter=letter)
-    logging.info(f"Fetching content of {baseos_frontpage}")
-    baseos_pkgs_html = requests.get(baseos_frontpage).content.decode("utf-8")
+for line in page_html.splitlines():
+    line = line.strip()
+    mo = re.match(r".*<a href=\"([^\"]+)\" title=.*", line)
+    if not mo:
+        continue
+    url = mo.group(1)
 
-    for line in baseos_pkgs_html.splitlines():
-        if not line.startswith("<a href=\""):
-            continue
-        line = line[len("<a href=\""):]
-        url = line[:line.index("\">")]
+    if el_ver not in url:
+        continue
 
-        if el_ver not in url:
-            continue
+    if not url.endswith("x86_64.rpm"):
+        continue
 
-        if not url.endswith("x86_64.rpm"):
-            continue
+    name, version, build = url.rsplit("-", 2)
 
-        name, version, build = url.rsplit("-", 2)
+    # glibc-2.28-236.el8.7.x86_64.rpm
+    if name == "glibc":
+        glibc_build1 = max(glibc_build1, int(build.split(".")[0]))
+        glibc_build2 = max(glibc_build2, int(build.split(".")[2]))
+        glibc_version = version
 
-        # glibc-2.28-236.el8.7.x86_64.rpm
-        if name == "glibc":
-            glibc_build1 = max(glibc_build1, int(build.split(".")[0]))
-            glibc_build2 = max(glibc_build2, int(build.split(".")[2]))
-            glibc_version = version
-
-        # kernel-headers-4.18.0-513.24.1.el8_9.x86_64.rpm
-        # kernel-headers-4.18.0-513.11.1.el8_9.0.1.x86_64.rpm
-        if name == "kernel-headers":
-            kernel_headers_build = max(kernel_headers_build, Version(build.rsplit(".", build.count(".") - 2)[0]))
-            kernel_headers_version = version
+    # kernel-headers-4.18.0-513.24.1.el8_9.x86_64.rpm
+    # kernel-headers-4.18.0-513.11.1.el8_9.0.1.x86_64.rpm
+    if name == "kernel-headers":
+        kernel_headers_build = max(kernel_headers_build, Version(build.rsplit(".", build.count(".") - 2)[0]))
+        kernel_headers_version = version
 
 if glibc_version == 0:
     raise ValueError("could not determine glibc version!")
@@ -125,7 +148,7 @@ def get_subfolder(pkg, string):
     # find in which subfolder the rpm lives on the rocky vault;
     # we assume that the layout for x86_64 works for all arches
     pkg_template = url_template + f"/{pkg}-{string}.x86_64.rpm"
-    for sf in ["BaseOS", "PowerTools", "AppStream"]:
+    for sf in ["BaseOS", "AppStream", "devel"]:
         url = pkg_template.format(arch="x86_64", subfolder=sf, letter=pkg[0])
         logging.info(f"Testing if {url} exists")
         if requests.get(url).status_code == 200:
@@ -151,7 +174,7 @@ for pkg, string in name2string.items():
         logging.info(f"Downloading {rpm_url}")
         r = requests.get(rpm_url)
         if r.status_code != 200:
-            logging.warning(f"Could not download rpm for {pkg} from {rpm_url}!")
+            logging.warning(f"{r.status_code}: Could not download rpm for {pkg} from {rpm_url}!")
             continue
         sha = hashlib.sha256(r.content).hexdigest();
         out_lines.append(f'    sha256: {sha}  # [cross_target_platform == "{conda_arch}"]')


### PR DESCRIPTION
linux-sysroot 2.34 

**Destination channel:** Defaults

### Links

- [PKG-11162]

### Explanation of changes:

- new GLIBC 2.34 for Rocky EL 9.5
  - [CF are 9.5](https://github.com/conda-forge/linux-sysroot-feedstock/blob/v2.34/recipe/meta.yaml) (previously 9.3)
- this should be being placed on the `v2.34` branch which is derived from `v2.28`
- this is intended to be one version advanced from the cbc.yaml default of [GLIBC 2.28](https://github.com/AnacondaRecipes/aggregate/blob/master/conda_build_config.yaml#L63) hence has *one* `track_features`
  - the pending `v2.39` branch for EL10 will have two `track_features`
- one change from 2.28 is that the glibc headers are only available for x86_64 -- because "biarch" (ie. has 32- and 64-bit variants) is an x86_64 thing and not an aarch64 thing (which only has 64-bit variants)
  - hence changes in `build.sh` and the tests
- otherwise we differ from CF because we use Rocky rather than Alma Linux which lays the HTML out that gets scraped differently and the packages have changed subdirectories
  - yes, it could have been rewritten to use beautiful soup


[PKG-11162]: https://anaconda.atlassian.net/browse/PKG-11162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ